### PR TITLE
Use callbacks in custom validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 
-import {BusybeeParsedConfig} from './models/config/BusybeeParsedConfig';
+import { BusybeeParsedConfig } from './models/config/BusybeeParsedConfig';
 require('source-map-support').install();
 import * as _ from 'lodash';
 import * as Commander from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 const appVersion = require('../../package.json').version;
-import {ConfigParser} from  './lib/ConfigParser';
-import {EnvManager} from './managers/EnvManager';
-import {TestManager} from './managers/TestManager';
-import {MockServer} from './lib/MockServer';
-import {Logger, LoggerConf} from 'busybee-util';
-import {EnvResult} from './models/results/EnvResult';
-import {TestSuiteResult} from './models/results/TestSuiteResult';
+import { ConfigParser } from './lib/ConfigParser';
+import { EnvManager } from './managers/EnvManager';
+import { TestManager } from './managers/TestManager';
+import { MockServer } from './lib/MockServer';
+import { Logger, LoggerConf } from 'busybee-util';
+import { EnvResult } from './models/results/EnvResult';
+import { TestSuiteResult } from './models/results/TestSuiteResult';
 
 let logger;
 const ONE_SECOND = 1000;
@@ -21,25 +21,47 @@ const ONE_MINUTE = ONE_SECOND * 60;
 const ONE_HOUR = ONE_MINUTE * 60;
 //process.env.UV_THREADPOOL_SIZE = '128';
 
-Commander
-  .version(appVersion);
+Commander.version(appVersion);
 
 // TODO: REMOVE protocol and host from cmdOpts...need to be per test suite
-Commander
-  .command('test')
+Commander.command('test')
   .description('execute tests')
-  .option('-c, --userConfigFile <userConfigFile>', 'Config File. defaults to userConfigFile.json. parsed as being relative to --directory')
+  .option(
+    '-c, --userConfigFile <userConfigFile>',
+    'Config File. defaults to userConfigFile.json. parsed as being relative to --directory'
+  )
   .option('-d, --directory <directory>', 'Test Directory. defaults to busybee/')
   .option('-D, --debug', 'convenience flag for debug mode')
-  .option('-l, --localMode', 'ignores any host configuration in favor of localhost with a capacity of 100')
+  .option(
+    '-l, --localMode',
+    'ignores any host configuration in favor of localhost with a capacity of 100'
+  )
   .option('-L, --logLevel <level>', '[DEBUG, INFO, WARN, ERROR]')
-  .option('-o, --onComplete <onComplete>', 'The filename of javascript module placed in your busybee/ directory. Will be called on complete. ex module) module.exports = (err, results) => { console.log(err || JSON.stringify(results)); }')
-  .option('-s, --skipEnvProvisioning <ids>', 'list of comma-separated TestSuite ids. Environments will not be provisioned for these TestSuites prior to running tests')
-  .option('-k, --skipTestSuite <ids>', 'list of comma-separated TestSuite ids to skip')
-  .option('-t, --testFiles <filenames>', 'list of comma-separated test files to run. ie) test.json,test2.json,users/mytest.json')
-  .option('-e, --envInstances <ids>', 'list of comma-separated envInstance ids to run')
-  .option('-w, --wsserver <port>', 'enable a websocket server at the specified port')
-  .action((options) => {
+  .option(
+    '-o, --onComplete <onComplete>',
+    'The filename of javascript module placed in your busybee/ directory. Will be called on complete. ex module) module.exports = (err, results) => { console.log(err || JSON.stringify(results)); }'
+  )
+  .option(
+    '-s, --skipEnvProvisioning <ids>',
+    'list of comma-separated TestSuite ids. Environments will not be provisioned for these TestSuites prior to running tests'
+  )
+  .option(
+    '-k, --skipTestSuite <ids>',
+    'list of comma-separated TestSuite ids to skip'
+  )
+  .option(
+    '-t, --testFiles <filenames>',
+    'list of comma-separated test files to run. ie) test.json,test2.json,users/mytest.json'
+  )
+  .option(
+    '-e, --envInstances <ids>',
+    'list of comma-separated envInstance ids to run'
+  )
+  .option(
+    '-w, --wsserver <port>',
+    'enable a websocket server at the specified port'
+  )
+  .action(options => {
     let configParser = new ConfigParser(options);
     const conf: BusybeeParsedConfig = configParser.parse('test');
     const loggerConf = new LoggerConf(this, conf.logLevel, null);
@@ -48,17 +70,27 @@ Commander
     initTests(conf);
   });
 
-Commander
-  .command('mock')
+Commander.command('mock')
   .description('runs a mockResponse REST API server using your tests as mocks')
-  .option('-c, --userConfigFile <userConfigFile>', 'Config File. defaults to userConfigFile.json. parsed as being relative to --directory')
+  .option(
+    '-c, --userConfigFile <userConfigFile>',
+    'Config File. defaults to userConfigFile.json. parsed as being relative to --directory'
+  )
   .option('-d, --directory <directory>', 'Test Directory. defaults to busybee/')
   .option('-D, --debug', 'convenience flag for debug mode')
   .option('-L, --logLevel <level>', '[DEBUG, INFO, WARN, ERROR]')
-  .option('-n, --noProxy, Will ignore any userConfigFile.json proxy configuration and skip proxy attempts')
-  .option('-t, --testSuite <id>', 'Required. The ID of the REST Api TestSuite that you would like to run a mock server for')
-  .option('-w, --wsserver <port>', 'enable a websocket server at the specified port')
-  .action((options) => {
+  .option(
+    '-n, --noProxy, Will ignore any userConfigFile.json proxy configuration and skip proxy attempts'
+  )
+  .option(
+    '-t, --testSuite <id>',
+    'Required. The ID of the REST Api TestSuite that you would like to run a mock server for'
+  )
+  .option(
+    '-w, --wsserver <port>',
+    'enable a websocket server at the specified port'
+  )
+  .action(options => {
     if (!options.testSuite) {
       console.log(`'--testSuite' is a required argument, exiting`);
       return;
@@ -68,38 +100,44 @@ Commander
     const loggerConf = new LoggerConf(this, conf.logLevel, null);
     logger = new Logger(loggerConf);
 
-
     // identify the TestSuite.
-    let testSuite = _.find(conf.parsedTestSuites.values(), (suite) => {
+    let testSuite = _.find(conf.parsedTestSuites.values(), suite => {
       return suite.suiteID == options.testSuite;
     });
     if (!testSuite) {
-      logger.error(`No TestSuite with the id ${options.testSuite} could be identified, exiting`);
-      return
+      logger.error(
+        `No TestSuite with the id ${
+          options.testSuite
+        } could be identified, exiting`
+      );
+      return;
     }
 
     new MockServer(testSuite, conf);
   });
 
-Commander
-  .command('init')
+Commander.command('init')
   .description('set up busybee folder and example userConfigFile/test')
   .action(() => {
     const exampleConf = require('./init/userConfigFile.json');
     const exampleTest = require('./init/test.json');
     const busybeeDir = path.join(process.cwd(), 'busybee');
-    if (!fs.existsSync(busybeeDir))
-      fs.mkdirSync(busybeeDir);
-    if (!fs.exists(path.join(busybeeDir, 'test.json'), null))
-      fs.writeFileSync(path.join(busybeeDir, 'test.json'), JSON.stringify(exampleTest, null, '\t'));
-    if (!fs.exists(path.join(busybeeDir, 'userConfigFile.json'), null))
-      fs.writeFileSync(path.join(busybeeDir, 'userConfigFile.json'), JSON.stringify(exampleConf, null, '\t'));
+    if (!fs.existsSync(busybeeDir)) fs.mkdirSync(busybeeDir);
+    if (!fs.existsSync(path.join(busybeeDir, 'test.json')))
+      fs.writeFileSync(
+        path.join(busybeeDir, 'test.json'),
+        JSON.stringify(exampleTest, null, '\t')
+      );
+    if (!fs.existsSync(path.join(busybeeDir, 'userConfigFile.json')))
+      fs.writeFileSync(
+        path.join(busybeeDir, 'userConfigFile.json'),
+        JSON.stringify(exampleConf, null, '\t')
+      );
 
-    console.log("Busybee initialized!");
+    console.log('Busybee initialized!');
   });
 
 Commander.parse(process.argv);
-
 
 function formatElapsed(start: number, end: number): string {
   let elapsed = end - start;
@@ -150,8 +188,7 @@ async function initTests(conf: BusybeeParsedConfig) {
   let testManager = new TestManager(conf, envManager);
 
   async function shutdown(err) {
-    if (err)
-      console.log(err);
+    if (err) console.log(err);
 
     try {
       await envManager.stopAll();
@@ -161,7 +198,6 @@ async function initTests(conf: BusybeeParsedConfig) {
       process.exit(1);
     }
   }
-
 
   process.on('uncaughtException', (err: Error) => {
     shutdown(err);
@@ -186,7 +222,7 @@ async function initTests(conf: BusybeeParsedConfig) {
   // flatten all env promises so that we can run them via Promise.all
   let envResultsPromises: Promise<EnvResult>[] = [];
   for (let suiteId in testManager.testSuiteTasks) {
-    testManager.testSuiteTasks[suiteId].envResults.forEach((envResultPromise) => {
+    testManager.testSuiteTasks[suiteId].envResults.forEach(envResultPromise => {
       envResultsPromises.push(envResultPromise);
     });
   }
@@ -203,7 +239,12 @@ async function initTests(conf: BusybeeParsedConfig) {
       // todo use TestSuiteResult model instead of any
       if (!suiteResults[envResult.suiteID]) {
         // create suiteResult if this suite hasn't been seen yet
-        let sr = new TestSuiteResult(envResult.suiteID, envResult.type, envResult.testSets, true);
+        let sr = new TestSuiteResult(
+          envResult.suiteID,
+          envResult.type,
+          envResult.testSets,
+          true
+        );
         suiteResults[envResult.suiteID] = sr;
       } else {
         suiteResults[envResult.suiteID].addEnvResult(envResult);
@@ -222,11 +263,15 @@ async function initTests(conf: BusybeeParsedConfig) {
       logger.info('Running Reporters');
       conf.reporters.forEach(r => {
         try {
-          if (conf.localMode && !_.isUndefined(r.skipInLocalMode) && r.skipInLocalMode) {
+          if (
+            conf.localMode &&
+            !_.isUndefined(r.skipInLocalMode) &&
+            r.skipInLocalMode
+          ) {
             return;
           }
 
-          r.run(busybeeTestResults)
+          r.run(busybeeTestResults);
         } catch (e) {
           logger.error('Error encountered while running reporter');
           logger.error(e);
@@ -235,7 +280,10 @@ async function initTests(conf: BusybeeParsedConfig) {
     }
 
     if (conf.onComplete) {
-      let scriptPath = conf.onComplete = path.join(conf.filePaths.busybeeDir, conf.onComplete);
+      let scriptPath = (conf.onComplete = path.join(
+        conf.filePaths.busybeeDir,
+        conf.onComplete
+      ));
 
       try {
         logger.info(`Running onComplete: ${scriptPath}`);
@@ -255,7 +303,10 @@ async function initTests(conf: BusybeeParsedConfig) {
     process.exit();
   } catch (err) {
     if (conf.onComplete) {
-      let scriptPath = conf.onComplete = path.join(conf.filePaths.busybeeDir, conf.onComplete);
+      let scriptPath = (conf.onComplete = path.join(
+        conf.filePaths.busybeeDir,
+        conf.onComplete
+      ));
 
       try {
         logger.info(`Running onComplete: ${scriptPath}`);
@@ -265,7 +316,9 @@ async function initTests(conf: BusybeeParsedConfig) {
       }
     } else {
       logger.trace(err);
-      if (!end) { end = Date.now(); }
+      if (!end) {
+        end = Date.now();
+      }
       logger.info(formatElapsed(start, end));
     }
   }

--- a/src/managers/RESTSuiteManager.ts
+++ b/src/managers/RESTSuiteManager.ts
@@ -250,7 +250,7 @@ export class RESTSuiteManager {
     }
   }
 
-  async wait(milliseconds) {
+  wait(milliseconds) {
     this.logger.debug(`wait ${milliseconds / 1000} second(s)`);
     return new Promise(resolve => setTimeout(resolve, milliseconds));
   }
@@ -459,7 +459,10 @@ export class RESTSuiteManager {
         // Run Custom Function Assertion OR basic Pojo comparision
         if (_.isFunction(test.expect.body)) {
           // if the test has a custom function for assertion, run it.
-          let bodyResult = await test.expect.body(actual, testSet.variableExports);
+          let bodyResult = test.expect.body(actual, testSet.variableExports);
+          if (instanceOf bodyResult === 'Promise') {
+            bodyResult = await bodyResult;
+          }
           if (bodyResult === false) {
             bodyPass = false;
           } // else we pass it. ie) it doesn't return anything we assume it passed.

--- a/src/managers/RESTSuiteManager.ts
+++ b/src/managers/RESTSuiteManager.ts
@@ -250,7 +250,7 @@ export class RESTSuiteManager {
     }
   }
 
-  wait(milliseconds) {
+  async wait(milliseconds) {
     this.logger.debug(`wait ${milliseconds / 1000} second(s)`);
     return new Promise(resolve => setTimeout(resolve, milliseconds));
   }
@@ -459,7 +459,7 @@ export class RESTSuiteManager {
         // Run Custom Function Assertion OR basic Pojo comparision
         if (_.isFunction(test.expect.body)) {
           // if the test has a custom function for assertion, run it.
-          let bodyResult = test.expect.body(actual, testSet.variableExports);
+          let bodyResult = await test.expect.body(actual, testSet.variableExports);
           if (bodyResult === false) {
             bodyPass = false;
           } // else we pass it. ie) it doesn't return anything we assume it passed.

--- a/src/managers/RESTSuiteManager.ts
+++ b/src/managers/RESTSuiteManager.ts
@@ -460,7 +460,7 @@ export class RESTSuiteManager {
         if (_.isFunction(test.expect.body)) {
           // if the test has a custom function for assertion, run it.
           let bodyResult = test.expect.body(actual, testSet.variableExports);
-          if (instanceOf bodyResult === 'Promise') {
+          if (bodyResult instanceof Promise) {
             bodyResult = await bodyResult;
           }
           if (bodyResult === false) {


### PR DESCRIPTION
Enables the usage of callbacks (async/await) within custom body validation functions. Busybee will await any Promise returned by the `body` lambda.

switch fs.exists to fs.existsSync - fs.exists returns a void in later versions which cannot be evaluated for truthiness. i think this is what you intended anyway.

the formatting changes I'm not sure where they came from - Husky does run pre-commit, so I assume that's linting.